### PR TITLE
Fix: Include layer 11 when loading transcoders

### DIFF
--- a/walkthrough.ipynb
+++ b/walkthrough.ipynb
@@ -252,7 +252,7 @@
     "transcoder_template = \"./gpt-2-small-transcoders/final_sparse_autoencoder_gpt2-small_blocks.{}.ln2.hook_normalized_24576\"\n",
     "transcoders = []\n",
     "frequencies = []\n",
-    "for i in range(11):\n",
+    "for i in range(12):\n",
     "    transcoders.append(SparseAutoencoder.load_from_pretrained(f\"{transcoder_template.format(i)}.pt\").eval())\n",
     "    frequencies.append(torch.load(f\"{transcoder_template.format(i)}_log_feature_sparsity.pt\"))"
    ]


### PR DESCRIPTION
I think this should be `range(12)` (0-11 inclusive) rather than `range(11)` (0-10 inclusive).

Ran into this when uploading layer 11 to Neuronpedia.